### PR TITLE
700M tokens from 2000+ top repos from the past year

### DIFF
--- a/datasets/github_data/filedata_20230624134702_1.parquet
+++ b/datasets/github_data/filedata_20230624134702_1.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b022c3554c501375060df7dfb26ca5770a7dc6c7bda1dc570576af93a3834c71
+size 27498552

--- a/datasets/github_data/filedata_20230624134702_10.parquet
+++ b/datasets/github_data/filedata_20230624134702_10.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b05752593aded88f4e6191edff4f4395130482ace98f6aec94c438753302b5ee
+size 13500602

--- a/datasets/github_data/filedata_20230624134702_11.parquet
+++ b/datasets/github_data/filedata_20230624134702_11.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:310a58a5805d887b1a9032a86dc0aa924e02e241b7d876c33d851c30a911d8ca
+size 50025455

--- a/datasets/github_data/filedata_20230624134702_12.parquet
+++ b/datasets/github_data/filedata_20230624134702_12.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23d5ce03f4fe54cbaa86867247923f785106878213d78db58fd1044110506425
+size 17493737

--- a/datasets/github_data/filedata_20230624134702_13.parquet
+++ b/datasets/github_data/filedata_20230624134702_13.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05af1099e3c1cb68583a7b1ffdcd768b7692bf62a4da33c8b01b236dfdeb2113
+size 16524533

--- a/datasets/github_data/filedata_20230624134702_14.parquet
+++ b/datasets/github_data/filedata_20230624134702_14.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5940f5effc60b1447e5b50a9dccf00874512a58304af5ddec495928264926ee
+size 11316957

--- a/datasets/github_data/filedata_20230624134702_15.parquet
+++ b/datasets/github_data/filedata_20230624134702_15.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c7cba78989a8c452edc2117c09da623ecb018b28e3b01a84f9211a0daf5bc0a
+size 32415999

--- a/datasets/github_data/filedata_20230624134702_16.parquet
+++ b/datasets/github_data/filedata_20230624134702_16.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7909d204cb8600042055e62ad7121ca213615213cd9666f0e6a75e1bf06911a
+size 5422834

--- a/datasets/github_data/filedata_20230624134702_17.parquet
+++ b/datasets/github_data/filedata_20230624134702_17.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83b10a57ba2f651b2fbdab72487c2b01522ca89c74951d6212c619f2492dd247
+size 19168373

--- a/datasets/github_data/filedata_20230624134702_18.parquet
+++ b/datasets/github_data/filedata_20230624134702_18.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c22719d6784ba18c026f23a96c15a90f31453e313430781f784a2a3eb1ca03c9
+size 15907147

--- a/datasets/github_data/filedata_20230624134702_19.parquet
+++ b/datasets/github_data/filedata_20230624134702_19.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1f780fb997b869e41a3df18b8bc4324564783031a04c9a55516804e0b49227e
+size 12009921

--- a/datasets/github_data/filedata_20230624134702_2.parquet
+++ b/datasets/github_data/filedata_20230624134702_2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f34962d566e1b6981955d39d5be48191cf490bfe14f3f555104fe2b3883eb1d4
+size 18924034

--- a/datasets/github_data/filedata_20230624134702_20.parquet
+++ b/datasets/github_data/filedata_20230624134702_20.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f3a8895f41a405c1abf32fa93fd7c7b582017fdf8795164a6e6486ef340040
+size 15351813

--- a/datasets/github_data/filedata_20230624134702_21.parquet
+++ b/datasets/github_data/filedata_20230624134702_21.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e0c9b3de086a30ab7829e374a7772949bd77b15e067453a104783550c000e9e
+size 15375808

--- a/datasets/github_data/filedata_20230624134702_22.parquet
+++ b/datasets/github_data/filedata_20230624134702_22.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd2108c91a5bc209999b8d9ca61e87256f58b37a757d7cdd536345fb7717277
+size 8195145

--- a/datasets/github_data/filedata_20230624134702_23.parquet
+++ b/datasets/github_data/filedata_20230624134702_23.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbb9118f5db2c6c16ca148786c57f8ac6dd6fcd05acb85b9e2abacd704b47111
+size 6485329

--- a/datasets/github_data/filedata_20230624134702_24.parquet
+++ b/datasets/github_data/filedata_20230624134702_24.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a2f8a366b8c48b52ac1ffcabc0743850f92f6601ee6d7284778f710ce05e44
+size 11067703

--- a/datasets/github_data/filedata_20230624134702_25.parquet
+++ b/datasets/github_data/filedata_20230624134702_25.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16d884384aa87e6a3fd9cfb801e8660f9f800d26f71040a331fc7488b6ea3ba1
+size 27900858

--- a/datasets/github_data/filedata_20230624134702_3.parquet
+++ b/datasets/github_data/filedata_20230624134702_3.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00a4b0757e856e31904bd4886addddbd0fff21fc37d03a70f96faf20b3183e7f
+size 19733155

--- a/datasets/github_data/filedata_20230624134702_4.parquet
+++ b/datasets/github_data/filedata_20230624134702_4.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc93a5052aa8c73477eb9f7fb61ea5005417a2f2774d6951f086bb315db933c
+size 17524692

--- a/datasets/github_data/filedata_20230624134702_5.parquet
+++ b/datasets/github_data/filedata_20230624134702_5.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2c2e39e7ccffd578f0a74bf9d0c8423ab3c987d8a02d9e45dd1accfca798e48
+size 22173666

--- a/datasets/github_data/filedata_20230624134702_6.parquet
+++ b/datasets/github_data/filedata_20230624134702_6.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31c4523e64607f8bf3280fc3f9e01099f62e8fc4da2c7b0096ab78131a89a174
+size 47282472

--- a/datasets/github_data/filedata_20230624134702_7.parquet
+++ b/datasets/github_data/filedata_20230624134702_7.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f86d14ebe72b03abd677627ad4de84d8564644aa4ce6a43952b36bba87f030a
+size 18107068

--- a/datasets/github_data/filedata_20230624134702_8.parquet
+++ b/datasets/github_data/filedata_20230624134702_8.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:841e43a2867c227aa15a95a15d9dc0d072caad7c7869013bf5a2fb71aab213ce
+size 9009286

--- a/datasets/github_data/filedata_20230624134702_9.parquet
+++ b/datasets/github_data/filedata_20230624134702_9.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a24374c8e628397c6825fd4ea4714661aaa8362c10e1443246393335cf05a7d6
+size 33502389

--- a/datasets/github_data/metadata_20230624134702_1.parquet
+++ b/datasets/github_data/metadata_20230624134702_1.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a38561a4f6014c9874644aba395b7b8cfac0e31fc0863d874050faa7440d42e
+size 133210

--- a/datasets/github_data/metadata_20230624134702_10.parquet
+++ b/datasets/github_data/metadata_20230624134702_10.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95ac15dff9a65410d1783d916a7433e7147e3be5272e97dc620842cbe0747c67
+size 122662

--- a/datasets/github_data/metadata_20230624134702_11.parquet
+++ b/datasets/github_data/metadata_20230624134702_11.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab52cdd63607b195e9430ca2d435c314de8cdf6870f0e27c5f0c770e8a2ddab2
+size 138584

--- a/datasets/github_data/metadata_20230624134702_12.parquet
+++ b/datasets/github_data/metadata_20230624134702_12.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f6bc437f1044319917914a98d0a9267f773fbc9db650f59945667edb8af944a
+size 138337

--- a/datasets/github_data/metadata_20230624134702_13.parquet
+++ b/datasets/github_data/metadata_20230624134702_13.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fd74fa346bf3dbaccf5167c9d8ac72cdd9da93589a509ab8737aa4ea8aaca73
+size 134434

--- a/datasets/github_data/metadata_20230624134702_14.parquet
+++ b/datasets/github_data/metadata_20230624134702_14.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1fdab1f8e52fa3d11e44fca564715a3f340370307458021ee83bc4e2f3ce70b
+size 140106

--- a/datasets/github_data/metadata_20230624134702_15.parquet
+++ b/datasets/github_data/metadata_20230624134702_15.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7ca24ed3f50828811a90b4c6480a636705cea4c3344113347fec85bef23997f
+size 132774

--- a/datasets/github_data/metadata_20230624134702_16.parquet
+++ b/datasets/github_data/metadata_20230624134702_16.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa807bcfa4aaf30bbeb8d0377a7c0f21484358919ba563c1951626488e7ba5cd
+size 135333

--- a/datasets/github_data/metadata_20230624134702_17.parquet
+++ b/datasets/github_data/metadata_20230624134702_17.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6959ca46f2835a5da978832c6cae2bdecffd01dabbbc3bca6cd2599c6b9b1aca
+size 129130

--- a/datasets/github_data/metadata_20230624134702_18.parquet
+++ b/datasets/github_data/metadata_20230624134702_18.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caddc2316d8d3141d18648ef3448ee64eba2e86ac2340028f5f42c7dd61cdfb4
+size 128855

--- a/datasets/github_data/metadata_20230624134702_19.parquet
+++ b/datasets/github_data/metadata_20230624134702_19.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e075b47cd058b9ca2ae22aa261a92667e96e48368ea31893e6ef2813df81aab2
+size 108440

--- a/datasets/github_data/metadata_20230624134702_2.parquet
+++ b/datasets/github_data/metadata_20230624134702_2.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb5b6b669cb5d8c369a379c04d89407e2f65d785a756c6457a65b9758d6a82d
+size 135886

--- a/datasets/github_data/metadata_20230624134702_20.parquet
+++ b/datasets/github_data/metadata_20230624134702_20.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98cc2f5bd9749b13e97fc62c0f3db8a030660a8aedc23e65a5a6837f5161a96b
+size 133826

--- a/datasets/github_data/metadata_20230624134702_21.parquet
+++ b/datasets/github_data/metadata_20230624134702_21.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db0d04f890f2b6c89831bfc3d3d43cb56db0265caa7a8ed3abff5b06cbb1e550
+size 122256

--- a/datasets/github_data/metadata_20230624134702_22.parquet
+++ b/datasets/github_data/metadata_20230624134702_22.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bdd2985a53ee8eeab4546aba231ca982e3a88b7559f25aa4204366eea8f336e
+size 137043

--- a/datasets/github_data/metadata_20230624134702_23.parquet
+++ b/datasets/github_data/metadata_20230624134702_23.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f9d32852b329c4c5d2850d5761bbf29fbc85da20fa86323f340075623af0d47
+size 131955

--- a/datasets/github_data/metadata_20230624134702_24.parquet
+++ b/datasets/github_data/metadata_20230624134702_24.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5107507dcf68b354984de753e86f836ff6fee8ee5a4a1583430b827c7cd0556
+size 134046

--- a/datasets/github_data/metadata_20230624134702_25.parquet
+++ b/datasets/github_data/metadata_20230624134702_25.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:341c935fd9a701a5aefc2f1370b1f2310b6350f8446271f4d815b5282d1db074
+size 99058

--- a/datasets/github_data/metadata_20230624134702_3.parquet
+++ b/datasets/github_data/metadata_20230624134702_3.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7a876de22c544096fb988c5a5ff2fc51c5de4c94441eec70154d9402c01d3a5
+size 138715

--- a/datasets/github_data/metadata_20230624134702_4.parquet
+++ b/datasets/github_data/metadata_20230624134702_4.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9bd9d0044b4f1f662ca80e967f52608eb5ddd997e2beb44d2b2f1c6855eddff
+size 137822

--- a/datasets/github_data/metadata_20230624134702_5.parquet
+++ b/datasets/github_data/metadata_20230624134702_5.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fa29724020cd1d8fc31ba201d6eac5d93f7f5f2f79c862fc4ab6576bc004e66
+size 134434

--- a/datasets/github_data/metadata_20230624134702_6.parquet
+++ b/datasets/github_data/metadata_20230624134702_6.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac4aa811bdc921d70606282c54d047fdf6453adca249e0a7f30e503db964cabc
+size 136473

--- a/datasets/github_data/metadata_20230624134702_7.parquet
+++ b/datasets/github_data/metadata_20230624134702_7.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37cca69b763d3cc1c5a543fca38bb55e187bb04ad68a9bdde05d441101b990ab
+size 139938

--- a/datasets/github_data/metadata_20230624134702_8.parquet
+++ b/datasets/github_data/metadata_20230624134702_8.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bca48ce8cdd6520e29b2998bd4a47f1267e44a88532bf91d7de2d2efdb9e043
+size 137631

--- a/datasets/github_data/metadata_20230624134702_9.parquet
+++ b/datasets/github_data/metadata_20230624134702_9.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:789ec6530713b89d49aa5496d52585162356b9d76c21e81642a11d371b601e1a
+size 133192


### PR DESCRIPTION
Freshly curated a few hours ago - contributing this dataset of top github repos from over the passed year. My custom built pipeline queries for top n repos over the last n days (here we are querying from the past year) and returns the files along with the repo metadata. In the parquet files below you will find 700 million tokens distributed amongst over 2000 repos. Should we make a new repo for this @0hq? Wasn't sure where/how to dump it. 